### PR TITLE
Shouldn't it preserve query string  when re-routing ?

### DIFF
--- a/src/Rerouters/NamedRouteRerouter.php
+++ b/src/Rerouters/NamedRouteRerouter.php
@@ -21,7 +21,11 @@ class NamedRouteRerouter implements Rerouter
 
         $url = route(
             $route->getName(),
-            [...$originalParameters, $parameterName => $actualValue]
+            [
+                ...$originalParameters,
+                $parameterName => $actualValue,
+                ...$this->request->query(),
+            ]
         );
 
         abort(redirect($url, status: 301));

--- a/tests/Feature/RouteBindingTest.php
+++ b/tests/Feature/RouteBindingTest.php
@@ -39,6 +39,20 @@ it('redirects to the correct URL if the slug is malformed', function () {
         ->assertRedirect(route('posts.show', $post));
 });
 
+it('redirects to the correct URL preserving query string if the slug is malformed', function () {
+    $post = PostFactory::new()->create();
+
+    Post::query()->paginate()->withQueryString();
+
+    Route::get('posts/{post}', function (Post $post) {
+    })->middleware('web')->name('posts.show');
+
+    $queryString = '?test=string';
+
+    $this->get('/posts/this-is-bogus-'.$post->getKey().$queryString)
+        ->assertRedirect(route('posts.show', $post).$queryString);
+});
+
 it('can redirect to non-get route', function () {
     $post = PostFactory::new()->create();
 


### PR DESCRIPTION
Consider implementing a self-healing mechanism for the product page URLs on our e-commerce site. In cases where a user has applied filters and the URL becomes malformed, the system should automatically append the query string to the URL. This way, even if the original URL is flawed, the user won't lose their applied filters, ensuring a seamless experience. However, if the query string itself is malformed, it may not be recoverable, but the priority is to preserve the user's chosen filters for a consistent and user-friendly navigation experience.