### PR TITLE
Update NamedRouteRerouter.php

### DIFF
--- a/src/Rerouters/NamedRouteRerouter.php
+++ b/src/Rerouters/NamedRouteRerouter.php
@@ -28,6 +28,6 @@ class NamedRouteRerouter implements Rerouter
             ]
         );
 
-        abort(redirect($url, status: 301));
+        abort(redirect($url, status: 307));
     }
 }


### PR DESCRIPTION
Change Overview: Updated the HTTP redirect status code from 301 Moved Permanently to 307 Temporary Redirect to ensure that the original HTTP method (e.g., POST, PUT, DELETE) is preserved during redirects.

Reason for Change:

The previous use of 301 Moved Permanently resulted in method conversion from POST to GET after a redirect. This caused issues with POST requests where the HTTP method needed to be preserved for the request to be processed correctly. By using 307 Temporary Redirect, the original HTTP method is maintained, preventing unintended method changes and ensuring the integrity of POST and other non-idempotent requests. Impact:

Ensures that form submissions and other POST requests are handled correctly without being inadvertently converted to GET requests due to redirection. Improves consistency in handling HTTP methods across redirects, aligning with best practices for redirect handling.